### PR TITLE
refactor: centralize logging and restrict debug flags

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../hooks/useAuth';
 import { getAllUsers, updateUserRole, getRoleChangeLogs, signOut, hasValidCredentials, supabase } from '../lib/supabase';
 import { User, RoleChangeLog } from '../types';
 import { EmployeeForm } from './EmployeeForm';
+import logger from '../lib/logger';
 import {
   Users,
   Shield,
@@ -77,7 +78,7 @@ export const AdminPanel: React.FC = () => {
       if (error) throw error;
       
       // Force refresh all data after successful update
-      console.log('Принудительное обновление списка пользователей...');
+      logger.info('Принудительное обновление списка пользователей...');
       await fetchUsers();
       await fetchRoleLogs();
       
@@ -87,7 +88,7 @@ export const AdminPanel: React.FC = () => {
       // Show success message
       alert(`Роль пользователя успешно изменена на "${getRoleDisplayName(role)}"`);
     } catch (error) {
-      console.error('Error updating role:', error);
+      logger.error('Error updating role:', error);
       
       // Check if the error is due to authentication issues
       if (error instanceof Error && 
@@ -121,10 +122,10 @@ export const AdminPanel: React.FC = () => {
       await fetchUsers();
       
       const statusText = !currentStatus ? 'активирован' : 'деактивирован';
-      console.log(`Пользователь ${statusText}`);
+      logger.info(`Пользователь ${statusText}`);
       alert(`Пользователь успешно ${statusText}`);
     } catch (error) {
-      console.error('Error updating user status:', error);
+      logger.error('Error updating user status:', error);
       alert(`Ошибка при изменении статуса пользователя: ${error instanceof Error ? error.message : 'Неизвестная ошибка'}`);
     } finally {
       setUpdating(false);

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -7,6 +7,7 @@ import { MapButton } from './MapDisplay';
 import { TaskPhotoChecklist } from './TaskPhotoChecklist';
 import KanbanBoard from './KanbanBoard';
 import { TaskApproval } from './TaskApproval';
+import logger from '../lib/logger';
 import { 
   Plus, 
   CheckSquare, 
@@ -94,7 +95,7 @@ const MapSelectorModal: React.FC<MapSelectorModalProps> = ({ center, onSelect, o
             setAddress(data.display_name);
           }
         } catch (error) {
-          console.warn('Reverse geocoding failed:', error);
+          logger.warn('Reverse geocoding failed:', error);
         }
       },
     });
@@ -399,7 +400,7 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
         .order('display_name');
 
       if (error) {
-        console.error('Error fetching task types:', error);
+        logger.error('Error fetching task types:', error);
         return;
       }
 
@@ -409,7 +410,7 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
         setTaskTypes([]);
       }
     } catch (err) {
-      console.error('Exception in fetchTaskTypes:', err);
+      logger.error('Exception in fetchTaskTypes:', err);
     }
   };
 
@@ -463,7 +464,7 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
             }
           }
         } catch (locationError) {
-          console.warn('Не удалось получить геолокацию:', locationError);
+          logger.warn('Не удалось получить геолокацию:', locationError);
           // Продолжаем без геолокации, но предупреждаем пользователя
           if (!confirm('Не удалось определить местоположение. Продолжить без GPS-координат?')) {
             return;
@@ -483,7 +484,7 @@ export const TaskManager: React.FC<TaskManagerProps> = () => {
       
       await fetchTasks();
     } catch (error) {
-      console.error('Ошибка обновления задачи:', error);
+      logger.error('Ошибка обновления задачи:', error);
       alert('Ошибка при обновлении статуса задачи');
     } finally {
       setUpdatingTask(null);
@@ -1173,7 +1174,7 @@ const TaskFormModal: React.FC<TaskFormModalProps> = ({
 
       onSuccess();
     } catch (error) {
-      console.error('Error creating task:', error);
+      logger.error('Error creating task:', error);
       alert(task ? 'Ошибка при обновлении задачи' : 'Ошибка при создании задачи');
     } finally {
       setLoading(false);

--- a/src/components/TimeTracker.tsx
+++ b/src/components/TimeTracker.tsx
@@ -5,6 +5,7 @@ import { WorkSession } from '../types';
 import { Play, Square, Clock, MapPin, DollarSign, Calendar, ArrowLeft } from 'lucide-react';
 import { format, formatDuration, intervalToDuration } from 'date-fns';
 import { ru } from 'date-fns/locale';
+import logger from '../lib/logger';
 
 interface TimeTrackerProps {
   onNavigate?: (view: string) => void;
@@ -82,7 +83,7 @@ export const TimeTracker: React.FC<TimeTrackerProps> = ({ onNavigate }) => {
         const position = await getCurrentLocation();
         location = formatLocation(position);
       } catch (locationError) {
-        console.warn('Geolocation failed:', locationError);
+        logger.warn('Geolocation failed:', locationError);
         const proceed = confirm(
           'Не удалось получить GPS координаты. Продолжить без записи местоположения?'
         );
@@ -104,7 +105,7 @@ export const TimeTracker: React.FC<TimeTrackerProps> = ({ onNavigate }) => {
       if (error) throw error;
       setCurrentSession(data);
     } catch (error) {
-      console.error('Error starting work:', error);
+      logger.error('Error starting work:', error);
       alert('Ошибка при начале работы.');
     } finally {
       setLoading(false);
@@ -122,7 +123,7 @@ export const TimeTracker: React.FC<TimeTrackerProps> = ({ onNavigate }) => {
         const position = await getCurrentLocation();
         location = formatLocation(position);
       } catch (locationError) {
-        console.warn('Geolocation failed:', locationError);
+        logger.warn('Geolocation failed:', locationError);
         const proceed = confirm(
           'Не удалось получить GPS координаты. Продолжить без записи местоположения?'
         );
@@ -160,7 +161,7 @@ export const TimeTracker: React.FC<TimeTrackerProps> = ({ onNavigate }) => {
       setCurrentSession(null);
       fetchRecentSessions();
     } catch (error) {
-      console.error('Error ending work:', error);
+      logger.error('Error ending work:', error);
       alert('Ошибка при завершении работы.');
     } finally {
       setLoading(false);

--- a/src/components/worker/WorkerSuperScreen.tsx
+++ b/src/components/worker/WorkerSuperScreen.tsx
@@ -14,6 +14,7 @@ import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { Truck, Pause, Camera, Phone } from 'lucide-react';
 import { format, startOfDay, endOfDay } from 'date-fns';
+import logger from '../../lib/logger';
 
 type ShiftStatus = 'idle' | 'running' | 'pause';
 
@@ -42,7 +43,7 @@ export function WorkerSuperScreen() {
   // Функция для логирования
   const log = (message: string, data?: any) => {
     const timestamp = new Date().toISOString();
-    console.log(`[WorkerScreen ${timestamp}] ${message}`, data || '');
+    logger.info(`[WorkerScreen ${timestamp}] ${message}`, data || '');
   };
 
   if (!hasValidCredentials || !supabase) {
@@ -226,7 +227,7 @@ export function WorkerSuperScreen() {
         fetchHistory()
       ]);
     } catch (error) {
-      console.error('Error initializing data:', error);
+      logger.error('Error initializing data:', error);
       setError('Ошибка загрузки данных');
     } finally {
       setLoading(false);
@@ -515,7 +516,7 @@ export function WorkerSuperScreen() {
         setGeoVerified(true);
         setOutside(false);
       } catch (locationError) {
-        console.warn('Geolocation failed:', locationError);
+        logger.warn('Geolocation failed:', locationError);
         setGeoVerified(false);
         const proceed = confirm(
           'Не удалось получить GPS координаты. Продолжить без записи местоположения?'
@@ -548,7 +549,7 @@ export function WorkerSuperScreen() {
       });
 
     } catch (error) {
-      console.error('Error starting work:', error);
+      logger.error('Error starting work:', error);
       toast({
         title: "Ошибка",
         description: "Не удалось начать смену",
@@ -594,7 +595,7 @@ export function WorkerSuperScreen() {
         log('Геолокация получена', { location });
       } catch (locationError) {
         log('Ошибка получения геолокации при завершении смены', { error: locationError });
-        console.warn('Geolocation failed:', locationError);
+        logger.warn('Geolocation failed:', locationError);
       }
       
       const endTime = new Date();
@@ -666,7 +667,7 @@ export function WorkerSuperScreen() {
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined
       });
-      console.error('Error ending work:', error);
+      logger.error('Error ending work:', error);
       toast({
         title: "Ошибка",
         description: "Не удалось завершить смену",
@@ -771,7 +772,7 @@ export function WorkerSuperScreen() {
         fetchTasks();
       }, 1000);
     } catch (error) {
-      console.error('Error pausing task:', error);
+      logger.error('Error pausing task:', error);
       toast({
         title: "Ошибка",
         description: "Не удалось приостановить задачу",
@@ -866,7 +867,7 @@ export function WorkerSuperScreen() {
           }
         }
       } catch (locationError) {
-        console.warn('Location check failed:', locationError);
+        logger.warn('Location check failed:', locationError);
         const shouldContinue = confirm(
           'Не удалось проверить ваше местоположение. Продолжить без проверки?'
         );
@@ -917,7 +918,7 @@ export function WorkerSuperScreen() {
         const position = await getCurrentLocation();
         location = formatLocation(position);
       } catch (locationError) {
-        console.warn('Geolocation failed:', locationError);
+        logger.warn('Geolocation failed:', locationError);
       }
 
       if (isResuming) {
@@ -1013,7 +1014,7 @@ export function WorkerSuperScreen() {
         fetchTasks();
       }, 1000);
     } catch (error) {
-      console.error('Error starting task:', error);
+      logger.error('Error starting task:', error);
       toast({
         title: "Ошибка",
         description: "Не удалось начать задачу",
@@ -1070,7 +1071,7 @@ export function WorkerSuperScreen() {
         const position = await getCurrentLocation();
         location = formatLocation(position);
       } catch (locationError) {
-        console.warn('Geolocation failed:', locationError);
+        logger.warn('Geolocation failed:', locationError);
       }
 
       let updateData: TaskUpdate = {
@@ -1124,10 +1125,10 @@ export function WorkerSuperScreen() {
           body: payload,
         });
       } catch (notifyError) {
-        console.warn('Notify manager failed (non-blocking):', notifyError);
+        logger.warn('Notify manager failed (non-blocking):', notifyError);
       }
     } catch (error) {
-      console.error('Error completing task:', error);
+      logger.error('Error completing task:', error);
       toast({
         title: "Ошибка",
         description: "Не удалось завершить задачу",

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,26 @@
+const levelOrder = { debug: 0, info: 1, warn: 2, error: 3 } as const;
+
+type Level = keyof typeof levelOrder;
+
+const currentLevel: Level = process.env.NODE_ENV === 'production' ? 'error' : 'debug';
+
+function shouldLog(level: Level) {
+  return levelOrder[level] >= levelOrder[currentLevel];
+}
+
+const logger = {
+  debug: (...args: unknown[]) => {
+    if (shouldLog('debug')) console.debug(...args);
+  },
+  info: (...args: unknown[]) => {
+    if (shouldLog('info')) console.info(...args);
+  },
+  warn: (...args: unknown[]) => {
+    if (shouldLog('warn')) console.warn(...args);
+  },
+  error: (...args: unknown[]) => {
+    if (shouldLog('error')) console.error(...args);
+  }
+};
+
+export default logger;

--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -1,4 +1,6 @@
 // Telegram WebApp integration for unified project
+import logger from './logger';
+
 declare global {
   interface Window {
     Telegram?: {
@@ -29,25 +31,25 @@ export class TelegramWebApp {
   private static instance: TelegramWebApp;
 
   private constructor() {
-    console.log('🚀 TelegramWebApp constructor called');
-    
+    logger.debug('🚀 TelegramWebApp constructor called');
+
     if (this.isTelegramEnvironment()) {
-      console.log('📱 Telegram WebApp detected, initializing...');
+      logger.debug('📱 Telegram WebApp detected, initializing...');
       try {
         window.Telegram!.WebApp.ready();
         window.Telegram!.WebApp.expand();
-        console.log('✅ Telegram WebApp initialized successfully');
-        console.log('📋 WebApp info:', {
+        logger.debug('✅ Telegram WebApp initialized successfully');
+        logger.debug('📋 WebApp info:', {
           platform: window.Telegram!.WebApp.platform,
           version: window.Telegram!.WebApp.version,
           initData: window.Telegram!.WebApp.initData ? 'present' : 'empty',
           user: window.Telegram!.WebApp.initDataUnsafe?.user ? 'present' : 'empty'
         });
       } catch (error) {
-        console.error('❌ Telegram WebApp initialization failed:', error);
+        logger.error('❌ Telegram WebApp initialization failed:', error);
       }
     } else {
-      console.log('🌐 Not in Telegram environment');
+      logger.debug('🌐 Not in Telegram environment');
     }
   }
 
@@ -64,13 +66,13 @@ export class TelegramWebApp {
     const hasNgrok = hasWindow && window.location.hostname.includes('ngrok');
     const hasUser = hasWindow && !!window.Telegram?.WebApp?.initDataUnsafe?.user;
     const params = hasWindow ? new URLSearchParams(window.location.search) : null;
-    const isDev = import.meta.env.DEV;
+    const isDev = process.env.NODE_ENV !== 'production';
     const forceTelegram = isDev && params?.get('force_telegram') === '1';
     const hasTestUserParam = isDev && Boolean(params?.get('telegram_id'));
     const hash = hasWindow ? (window.location.hash || '') : '';
     const hasTgWebAppData = isDev && hasWindow && hash.includes('tgWebAppData=');
-    
-    console.log('🔍 Environment check:', {
+
+    logger.debug('🔍 Environment check:', {
       hasWindow,
       hasTelegram,
       hasNgrok,
@@ -87,14 +89,14 @@ export class TelegramWebApp {
   }
 
   public getTelegramUser() {
-    console.log('🔍 Getting Telegram user...');
-    
-    const isDev = import.meta.env.DEV;
+    logger.debug('🔍 Getting Telegram user...');
+
+    const isDev = process.env.NODE_ENV !== 'production';
     // Разрешаем тестовый сценарий с параметром telegram_id только в режиме разработки
     const urlParams = new URLSearchParams(window.location.search);
     const testUserId = isDev ? urlParams.get('telegram_id') : null;
     if (testUserId) {
-      console.log('🧪 Using test Telegram ID from URL:', testUserId);
+      logger.debug('🧪 Using test Telegram ID from URL:', testUserId);
       return {
         id: parseInt(testUserId),
         first_name: 'Тестовый',
@@ -105,14 +107,14 @@ export class TelegramWebApp {
     }
 
     if (!this.isTelegramEnvironment()) {
-      console.log('🌐 Not in Telegram environment and no test user; returning null');
+      logger.debug('🌐 Not in Telegram environment and no test user; returning null');
       return null;
     }
 
     // Основной источник — initDataUnsafe.user
     let user = window.Telegram!.WebApp.initDataUnsafe.user;
     if (user) {
-      console.log('👤 Telegram user (initDataUnsafe):', user);
+      logger.debug('👤 Telegram user (initDataUnsafe):', user);
       return user;
     }
 
@@ -127,32 +129,32 @@ export class TelegramWebApp {
           const userStr = kv.get('user');
           if (userStr) {
             const parsed = JSON.parse(decodeURIComponent(userStr));
-            console.log('👤 Telegram user (parsed from tgWebAppData hash):', parsed);
+            logger.debug('👤 Telegram user (parsed from tgWebAppData hash):', parsed);
             return parsed;
           }
         }
       } catch (e) {
-        console.warn('⚠️ Failed to parse tgWebAppData from hash:', e);
+        logger.warn('⚠️ Failed to parse tgWebAppData from hash:', e);
       }
     }
 
-    console.log('⚠️ Telegram user not found');
+    logger.info('⚠️ Telegram user not found');
     return null;
   }
 
   public showAlert(message: string) {
     if (this.isTelegramEnvironment()) {
-      console.log('📱 Telegram alert:', message);
+      logger.info('📱 Telegram alert:', message);
       // In real Telegram environment, we could use native alerts
     } else {
-      console.log('🌐 Browser alert:', message);
+      logger.info('🌐 Browser alert:', message);
       alert(message);
     }
   }
 
   public hapticFeedback(type: 'light' | 'medium' | 'heavy' = 'light') {
     if (this.isTelegramEnvironment()) {
-      console.log(`📳 Haptic feedback: ${type}`);
+      logger.info(`📳 Haptic feedback: ${type}`);
       // In real implementation, would use Telegram's haptic API
     }
   }


### PR DESCRIPTION
## Summary
- add configurable logger utility with debug/info/warn/error levels
- remove production use of debug and force flags in auth flow and Telegram integration
- replace scattered console logging with centralized logger across components and libs

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68bafa4349e08326b794c54925dcbed4